### PR TITLE
Declare required dependency on `check` package

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,6 +12,7 @@ Package.onUse(function(api) {
   api.use('jagi:reactive-map@0.2.1');
   api.use('underscore');
   api.use('ui');
+  api.use('check');
 
   api.imply('jagi:astronomy');
 


### PR DESCRIPTION
- Fix `ReferenceError: Match is not defined` when this package is loaded
  before the `check` package

I created [this repo](https://github.com/NimbleNotes/astronomy-validators-test) to reproduce the error. This only happens when using this package from another package (meteor _apps_ are safe since it appears meteor is loading `check` prior to any packages loading, which would explain why I couldn't reproduce this error in a meteor app).
