### PR TITLE
maxLength should validate empty strings/arrays

### DIFF
--- a/lib/validators/size/max_length.js
+++ b/lib/validators/size/max_length.js
@@ -2,7 +2,7 @@ Astro.createValidator({
   name: 'maxLength',
   validate: function(fieldValue, fieldName, maxLength) {
     if (!fieldValue) {
-      return false;
+      return true;
     }
 
     return fieldValue.length <= maxLength;


### PR DESCRIPTION
I couldn't use maxLength for a string that should be less than n characters but could eventually be empty.
maxLength should return true for empty strings/arrays, as this validator should only check that a string/array is not too long.
