### PR TITLE
adding possible fix for validating against NaN

### DIFF
--- a/lib/validators/type/number.js
+++ b/lib/validators/type/number.js
@@ -1,6 +1,8 @@
 Astro.createValidator({
   name: 'number',
-  validate: _.isNumber,
+  validate: function(value) {
+  	return !_.isNaN(value) && _.isNumber(value);
+  },
   events: {
     validationerror: function(e) {
       var fieldName = e.data.field;

--- a/test/validators.js
+++ b/test/validators.js
@@ -103,6 +103,12 @@ Tinytest.add('Validators module - Validators', function(test) {
   test.isFalse(itemB.validate('number'),
     'Should not pass "number" validation'
   );
+  // NaN case
+  itemB.set('number', NaN);
+  test.isFalse(itemB.validate('number'),
+    'Should not pass "number" validation when NaN'
+  );
+
   test.isFalse(itemB.validate('boolean'),
     'Should not pass "boolean" validation'
   );
@@ -166,6 +172,7 @@ Tinytest.add('Validators module - Validators', function(test) {
   test.isFalse(itemB.validate('lte'),
     'Should not pass "lte" validation'
   );
+
   // Comparison.
   itemB.set('choice', 'abc');
   itemB.set('unique', 'abc');


### PR DESCRIPTION
When using Validator.number() on a field the Class instance casts the field if it is has `type: "number"` converting the value to `NaN`. When `instance.validateAll()` is run, it uses `_.isNumber()` on the value which returns true for `NaN` type. This seems like confusing behavior.
