### PR TITLE
Looks like the event.field does not match up w/ astronomy's afterSet event

### DIFF
--- a/lib/module/init_class.js
+++ b/lib/module/init_class.js
@@ -77,7 +77,7 @@ var classMethods = {
 var events = {};
 
 events.afterSet = function(e) {
-  var fieldName = e.data.field;
+  var fieldName = e.data.fieldName;
 
   // If a validator is defined for given field then clear error message for
   // that field.


### PR DESCRIPTION
`event.field` should be  `event.fieldName` otherwise the error won't get deleted.  
