### PR TITLE
suggestion for .catchValidationException

### DIFF
--- a/lib/module/get_error.js
+++ b/lib/module/get_error.js
@@ -103,7 +103,7 @@ methods.catchValidationException = function(exception) {
     exception.error !== 'validation-error' ||
     !_.isObject(exception.reason)
   ) {
-    return;
+    return exception;
   }
 
   var doc = this;

--- a/lib/module/get_error.js
+++ b/lib/module/get_error.js
@@ -103,7 +103,7 @@ methods.catchValidationException = function(exception) {
     exception.error !== 'validation-error' ||
     !_.isObject(exception.reason)
   ) {
-    return exception;
+    return false;
   }
 
   var doc = this;
@@ -120,6 +120,7 @@ methods.catchValidationException = function(exception) {
       }
     );
   });
+  return true;
 };
 
 _.extend(Astro.BaseClass.prototype, methods);


### PR DESCRIPTION
Hi,

I thought it might be useful to return the exception if it's not something that `.catchValidationException()` can handle. Example:

```
// server
if (!model.validate()) {
    model.throwValidationException();
}
model.save();
return model;

// client
Meteor.call('some-save-method', model, function(error, result) {
    error = model.catchValidationException(error);
    if (error) {
        // do my own handling for a non-validation type exception
        return;
    } 
    // no errors, so do something else
    alert('success');
});

```

Otherwise, I don't think there's a way to distinguish when the error is handled by model or not. 
