### PR TITLE
need to remove existing error

### DIFF
--- a/lib/module/validate.js
+++ b/lib/module/validate.js
@@ -12,8 +12,9 @@ methods._validateOne = function(fieldName, stopOnFirstError) {
       var nestedFieldValue = nestedDoc.get(nestedFieldName);
 
       // If value of the field is optional and it's null, then we passed
-      // validation.
+      // validation. Clear any existing error
       if (_.isNull(nestedFieldValue) && field.optional) {
+        nestedDoc._errors.delete(nestedFieldName);
         return;
       }
 


### PR DESCRIPTION
When the field is optional and is invalidated the error will persist even when the end user changes the field back to null. The error should be removed. 
