### PR TITLE
Give comparison field name to error message in equalTo validator

### DIFF
--- a/lib/validators/comparison/equal_to.js
+++ b/lib/validators/comparison/equal_to.js
@@ -13,7 +13,7 @@ Astro.createValidator({
 
       e.setMessage(
         'The values of the "' + fieldName + '" and "' +
-        compareValue + '" fields have to be equal'
+        compareFieldName + '" fields have to be equal'
       );
     }
   }


### PR DESCRIPTION
I noticed that the error message gets the value it's compared against, rather than the field name, so I would see:

```
{update_date: "The values of the "update_date" and "Mon Jan 25 2016 15:27:27 GMT+0000 (GMT)" fields have to be equal"}
```

Instead of:

```
{update_date: "The values of the "update_date" and "resolved_date" fields have to be equal"}
```
